### PR TITLE
New to_string funtionality added

### DIFF
--- a/lib/ECAD/EN81346.pm
+++ b/lib/ECAD/EN81346.pm
@@ -237,7 +237,58 @@ sub to_string($;$) {
     my $string_representation = '';
     foreach my $key (&sort(keys(%segments))) {
         if ($identifier && $key ne $identifier) {next;}
-        $string_representation .= $key . join('.', @{$segments{$key}})
+        $string_representation .= $key . join('.', @{$segments{$key}});
+    };
+    return $string_representation;
+}
+
+sub to_string2($;$) {
+    my ($args, $identifier) = @_;
+    my %segments;
+
+    # Checking, whether the passed argument is a reference
+    # or a string.
+    if (ref($args) eq 'HASH') {
+        %segments = %{$args};
+    }
+    else {
+        %segments = &segments($args);
+    }
+
+    my $string_representation = '';
+    foreach my $key (&sort(keys(%segments))) {
+        if ($identifier && $key ne $identifier) {next;}
+        $string_representation .= $key . join($key, @{$segments{$key}});
+    };
+    return $string_representation;
+}
+
+sub to_string3($;$) {
+    my ($args, $identifier) = @_;
+    my %segments;
+
+    # Checking, whether the passed argument is a reference
+    # or a string.
+    if (ref($args) eq 'HASH') {
+        %segments = %{$args};
+    }
+    else {
+        %segments = &segments($args);
+    }
+
+    my $string_representation = '';
+    foreach my $key (&sort(keys(%segments))) {
+        if ($identifier && $key ne $identifier) {next;}
+        # Building the string representation in mixed mode. This means, if an element
+        # only contains numbers it will divides by a dot instead the key delimiter.
+        # The $level counter is used to ensure, the first element of a representation is always
+        # leading by the full delimiter and not the dot notation
+        my $level = 0;
+        foreach my $segment ( @{$segments{$key}} ) {
+            my $delimiter = $segment =~ m/^[0-9]+$/ && $level > 0 ? '.' : $key;
+            $string_representation .= $delimiter . $segment;
+            $level++;
+        }
     };
     return $string_representation;
 }

--- a/t/01-EN81346.t
+++ b/t/01-EN81346.t
@@ -69,6 +69,16 @@ is(ECAD::EN81346::to_string('==FZ910==Z2=113++CAB+1CC01'), '==FZ910.Z2=113++CAB+
 is(ECAD::EN81346::to_string('==FZ910==Z2=113++CAB+1CC01', '='), '=113', 'to_string String building testing');
 is(ECAD::EN81346::to_string('==FZ910==Z2=113++CAB+1CC01', '=='), '==FZ910.Z2', 'to_string String building testing');
 
+# The full mode to_string
+is(ECAD::EN81346::to_string2('==FZ910==Z2=113++CAB+1C+C01+1'), '==FZ910==Z2=113++CAB+1C+C01+1', 'to_string2 String building testing');
+is(ECAD::EN81346::to_string2('==FZ910==Z2=113++CAB+1CC01', '='), '=113', 'to_string2 String building testing');
+is(ECAD::EN81346::to_string2('==FZ910==Z2=113++CAB+1CC01', '=='), '==FZ910==Z2', 'to_string2 String building testing');
+
+# The mixed mode to_string
+is(ECAD::EN81346::to_string3('==FZ910==Z2=113++CAB+1C+C01+1'), '==FZ910==Z2=113++CAB+1C+C01.1', 'to_string3 String building testing');
+is(ECAD::EN81346::to_string3('==FZ910==Z2=113.4++CAB+1C+C01+1', '='), '=113.4', 'to_string3 String building testing');
+is(ECAD::EN81346::to_string3('==FZ910==2=113++CAB+1C+C01+1', '=='), '==FZ910.2', 'to_string3 String building testing');
+
 # Testing the sort implementation of the ID sorting
 my @tests = (
     {


### PR DESCRIPTION
I have added two new "to_string" methods to create the output strings.
"to_string2" builds the string completely with the full separators, while "to_string3" uses a mixed method in which the full separators are used, unless the element contains only numbers and no letters. In this case, the dot is used as the separator.

See also #1 